### PR TITLE
Alternative Part Insert Test Added for issue #8

### DIFF
--- a/resources/testdata/src_changetypes/AlternativePartInsert2_Left.java
+++ b/resources/testdata/src_changetypes/AlternativePartInsert2_Left.java
@@ -1,0 +1,23 @@
+public class Compute {
+  MessageQueue mq;
+
+  public Compute(MessageQueue mq) {
+    this.mq = mq;
+  }
+
+  public int countNumberOfOccurrences(String e) {
+    if (mq.size() == 0) {
+      return -1;
+    }
+    if (!mq.contains(e)) {
+      return 0;
+    }
+    int counter = 0;
+    for (int i = 0; i < mq.size(); i++) {
+      if (e.equals(mq.getAt(i))) {
+        counter++;
+      }
+    }
+    return counter;
+  }
+}

--- a/resources/testdata/src_changetypes/AlternativePartInsert2_Right.java
+++ b/resources/testdata/src_changetypes/AlternativePartInsert2_Right.java
@@ -1,0 +1,24 @@
+public class Compute {
+  MessageQueue mq;
+
+  public Compute(MessageQueue mq) {
+    this.mq = mq;
+  }
+
+  public int countNumberOfOccurrences(String e) {
+    if (mq.size() == 0) {
+      return -1;
+    }
+    if (!mq.contains(e)) {
+      return 0;
+    }
+    int counter = 0;
+    for (int i = 0; i < mq.size(); i++) {
+      if (e.equals(mq.getAt(i))) {
+        counter++;
+      }
+      else{}
+    }
+    return counter;
+  }
+}

--- a/resources/testdata/src_changetypes/AlternativePartInsert3_Left.java
+++ b/resources/testdata/src_changetypes/AlternativePartInsert3_Left.java
@@ -1,0 +1,19 @@
+public class SwitchCaseExample2 {
+
+   public static void main(String args[]){
+      int i=2;
+      switch(i)
+      {
+	 case 1:
+	   System.out.println("Case1 ");
+	 case 2:
+	   System.out.println("Case2 ");
+	 case 3:
+	   System.out.println("Case3 ");
+	 case 4:
+           System.out.println("Case4 ");
+	 default:
+	   System.out.println("Default ");
+      }
+   }
+}

--- a/resources/testdata/src_changetypes/AlternativePartInsert3_Right.java
+++ b/resources/testdata/src_changetypes/AlternativePartInsert3_Right.java
@@ -1,0 +1,20 @@
+public class SwitchCaseExample2 {
+
+   public static void main(String args[]){
+      int i=2;
+      switch(i)
+      {
+	 case 1:
+	   System.out.println("Case1 ");
+	 case 2:
+	   System.out.println("Case2 ");
+	 case 3:
+	   System.out.println("Case3 ");
+	 case 4:
+           System.out.println("Case4 ");
+	 case 5:
+	 default:
+	   System.out.println("Default ");
+      }
+   }
+}

--- a/resources/testdata/src_changetypes/AlternativePartInsert_Left.java
+++ b/resources/testdata/src_changetypes/AlternativePartInsert_Left.java
@@ -1,0 +1,23 @@
+public class Compute {
+  MessageQueue mq;
+
+  public Compute(MessageQueue mq) {
+    this.mq = mq;
+  }
+
+  public int countNumberOfOccurrences(String e) {
+    if (mq.size() == 0) {
+      return -1;
+    }
+    if (!mq.contains(e)) {
+      return 0;
+    }
+    int counter = 0;
+    for (int i = 0; i < mq.size(); i++) {
+      if (e.equals(mq.getAt(i))) {
+        counter++;
+      }
+    }
+    return counter;
+  }
+}

--- a/resources/testdata/src_changetypes/AlternativePartInsert_Right.java
+++ b/resources/testdata/src_changetypes/AlternativePartInsert_Right.java
@@ -1,0 +1,24 @@
+public class Compute {
+  MessageQueue mq;
+
+  public Compute(MessageQueue mq) {
+    this.mq = mq;
+  }
+
+  public int countNumberOfOccurrences(String e) {
+    if (mq.size() == 0) {
+      return -1;
+    }
+    if (!mq.contains(e)) {
+      return 0;
+    }
+    else{}
+    int counter = 0;
+    for (int i = 0; i < mq.size(); i++) {
+      if (e.equals(mq.getAt(i))) {
+        counter++;
+      }
+    }
+    return counter;
+  }
+}

--- a/src/test/java/ch/uzh/ifi/seal/changedistiller/unittest/AlternativePartInsertTest.java
+++ b/src/test/java/ch/uzh/ifi/seal/changedistiller/unittest/AlternativePartInsertTest.java
@@ -1,0 +1,85 @@
+package ch.uzh.ifi.seal.changedistiller.unittest;
+
+/*
+ * #%L
+ * ChangeDistiller
+ * %%
+ * Copyright (C) 2011 - 2018 Software Architecture and Evolution Lab, Department of Informatics, UZH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import ch.uzh.ifi.seal.changedistiller.model.entities.SourceCodeChange;
+
+import ch.uzh.ifi.seal.changedistiller.ChangeDistiller;
+import ch.uzh.ifi.seal.changedistiller.ChangeDistiller.Language;
+import ch.uzh.ifi.seal.changedistiller.distilling.FileDistiller;
+import ch.uzh.ifi.seal.changedistiller.model.entities.SourceCodeChange;
+public class AlternativePartInsertTest {
+	List<SourceCodeChange> sourceCodeChangeList;
+	
+	@Before
+	public void setUp() {
+		sourceCodeChangeList = FileDistillerUtil.getChangesFromFile("AlternativePartInsert_Left.java", "AlternativePartInsert_Right.java");
+	}
+    @Test
+	public void alternativePartInsertTest() {
+		String expected = "ALTERNATIVE_PART_INSERT\n";
+		StringBuilder stringBuilder = new StringBuilder();
+		for(SourceCodeChange change : sourceCodeChangeList) {
+			stringBuilder.append(change.getLabel() + "\n");
+		}
+		
+		assertEquals(stringBuilder.toString(), expected);
+	}
+	@Before
+	public void setUp2() {
+		sourceCodeChangeList = FileDistillerUtil.getChangesFromFile("AlternativePartInsert2_Left.java", "AlternativePartInsert2_Right.java");
+	}
+    @Test
+	public void alternativePartInsertTest2() {
+		String expected = "ALTERNATIVE_PART_INSERT\n";
+		StringBuilder stringBuilder = new StringBuilder();
+		for(SourceCodeChange change : sourceCodeChangeList) {
+			stringBuilder.append(change.getLabel() + "\n");
+		}
+		
+		assertEquals(stringBuilder.toString(), expected);
+	}
+	@Before
+	public void setUp3() {
+		sourceCodeChangeList = FileDistillerUtil.getChangesFromFile("AlternativePartInsert2_Left.java", "AlternativePartInsert2_Right.java");
+	}
+    @Test
+	public void alternativePartInsertTest3() {
+		String expected = "ALTERNATIVE_PART_INSERT\n";
+		StringBuilder stringBuilder = new StringBuilder();
+		for(SourceCodeChange change : sourceCodeChangeList) {
+			stringBuilder.append(change.getLabel() + "\n");
+		}
+		
+		assertEquals(stringBuilder.toString(), expected);
+	}
+}


### PR DESCRIPTION
Alternative part insert test checks whether the second code has new parts defined as an alternative part to the first code.