### PR TITLE
PARENT_CLASS_DELETE unit test added. #29

### DIFF
--- a/resources/testdata/src_changetypes/ParentClassDeleteFail_Left.java
+++ b/resources/testdata/src_changetypes/ParentClassDeleteFail_Left.java
@@ -1,0 +1,74 @@
+package test;
+
+/**
+ * This is our first (left) test class.
+ * @author Beat Fluri
+ */
+public class Test extends Object{
+
+	/*
+	 * Scarab Lord Kungen
+	 */
+	public String aField;
+
+	public static String sField;
+	public volatile int vField;
+	public transient String tField;
+	public synchronized long synchField;
+
+	private String arrayField;
+
+	public Integer anInteger = new Integer(1);
+
+	/**
+	 * Yet another method with a comment
+	 * @param number
+	 * @return
+	 */
+	public int foo(int number) {
+		System.out.println("left");
+
+		// check if number is greater than -1
+		boolean check = number > 0;
+		int a = 0;
+		int b = 2;
+
+		// check the huga number
+		// and some new
+
+		if (check) {
+			/* This is the most beautiful comment in the world
+			 * and soon it will be gone :'(
+			 */
+			a = 23 + Integer.parseInt("42");
+			b = Math.round(Math.random() /* mimimi */);
+			return a + b;
+		} else {
+			/* huga bimbo */
+			b = Math.abs(number);
+			String.valueOf(true);
+			return b;
+		}
+	}
+	/*
+	 * Inner classes are cool
+	 */
+
+	private class Bar {
+		private void method() {
+			System.out.println();
+			System.out.println();
+			System.out.println();
+		}
+	}
+	// the huga bar method
+	public void bar(int test) {
+		System.out.println("aString");
+	}
+
+	public native void nativeMethod();
+
+	public strictfp float strictfpMethod() {
+		return 2.0f * 3.3f;
+	}
+}

--- a/resources/testdata/src_changetypes/ParentClassDeleteFail_Right.java
+++ b/resources/testdata/src_changetypes/ParentClassDeleteFail_Right.java
@@ -1,0 +1,74 @@
+package test;
+
+/**
+ * This is our first (left) test class.
+ * @author Beat Fluri
+ */
+public class Test {
+
+	/*
+	 * Scarab Lord Kungen
+	 */
+	public String aField;
+
+	public static String sField;
+	public volatile int vField;
+	public transient String tField;
+	public synchronized long synchField;
+
+	private String arrayField;
+
+	public Integer anInteger = new Integer(1);
+
+	/**
+	 * Yet another method with a comment
+	 * @param number
+	 * @return
+	 */
+	public int foo(int number) {
+		System.out.println("left");
+
+		// check if number is greater than -1
+		boolean check = number > 0;
+		int a = 0;
+		int b = 2;
+
+		// check the huga number
+		// and some new
+
+		if (check) {
+			/* This is the most beautiful comment in the world
+			 * and soon it will be gone :'(
+			 */
+			a = 23 + Integer.parseInt("42");
+			b = Math.round(Math.random() /* mimimi */);
+			return a + b;
+		} else {
+			/* huga bimbo */
+			b = Math.abs(number);
+			String.valueOf(true);
+			return b;
+		}
+	}
+	/*
+	 * Inner classes are cool
+	 */
+
+	private class Bar {
+		private void method() {
+			System.out.println();
+			System.out.println();
+			System.out.println();
+		}
+	}
+	// the huga bar method
+	public void bar(int test) {
+		System.out.println("aString");
+	}
+
+	public native void nativeMethod();
+
+	public strictfp float strictfpMethod() {
+		return 2.0f * 3.3f;
+	}
+}

--- a/resources/testdata/src_changetypes/ParentClassDelete_Left.java
+++ b/resources/testdata/src_changetypes/ParentClassDelete_Left.java
@@ -1,0 +1,74 @@
+package test;
+
+/**
+ * This is our first (left) test class.
+ * @author Beat Fluri
+ */
+public class Test extends Object{
+
+	/*
+	 * Scarab Lord Kungen
+	 */
+	public String aField;
+
+	public static String sField;
+	public volatile int vField;
+	public transient String tField;
+	public synchronized long synchField;
+
+	private String arrayField;
+
+	public Integer anInteger = new Integer(1);
+
+	/**
+	 * Yet another method with a comment
+	 * @param number
+	 * @return
+	 */
+	protected int foo(int number) {
+		System.out.println("left");
+
+		// check if number is greater than -1
+		boolean check = number > 0;
+		int a = 0;
+		int b = 2;
+
+		// check the huga number
+		// and some new
+
+		if (check) {
+			/* This is the most beautiful comment in the world
+			 * and soon it will be gone :'(
+			 */
+			a = 23 + Integer.parseInt("42");
+			b = Math.round(Math.random() /* mimimi */);
+			return a + b;
+		} else {
+			/* huga bimbo */
+			b = Math.abs(number);
+			String.valueOf(true);
+			return b;
+		}
+	}
+	/*
+	 * Inner classes are cool
+	 */
+
+	private class Bar {
+		private void method() {
+			System.out.println();
+			System.out.println();
+			System.out.println();
+		}
+	}
+	// the huga bar method
+	public void bar(int test) {
+		System.out.println("aString");
+	}
+
+	public native void nativeMethod();
+
+	public strictfp float strictfpMethod() {
+		return 2.0f * 3.3f;
+	}
+}

--- a/resources/testdata/src_changetypes/ParentClassDelete_Right.java
+++ b/resources/testdata/src_changetypes/ParentClassDelete_Right.java
@@ -1,0 +1,74 @@
+package test;
+
+/**
+ * This is our first (left) test class.
+ * @author Beat Fluri
+ */
+public class Test {
+
+	/*
+	 * Scarab Lord Kungen
+	 */
+	public String aField;
+
+	public static String sField;
+	public volatile int vField;
+	public transient String tField;
+	public synchronized long synchField;
+
+	private String arrayField;
+
+	public Integer anInteger = new Integer(1);
+
+	/**
+	 * Yet another method with a comment
+	 * @param number
+	 * @return
+	 */
+	public int foo(int number) {
+		System.out.println("left");
+
+		// check if number is greater than -1
+		boolean check = number > 0;
+		int a = 0;
+		int b = 2;
+
+		// check the huga number
+		// and some new
+
+		if (check) {
+			/* This is the most beautiful comment in the world
+			 * and soon it will be gone :'(
+			 */
+			a = 23 + Integer.parseInt("42");
+			b = Math.round(Math.random() /* mimimi */);
+			return a + b;
+		} else {
+			/* huga bimbo */
+			b = Math.abs(number);
+			String.valueOf(true);
+			return b;
+		}
+	}
+	/*
+	 * Inner classes are cool
+	 */
+
+	private class Bar {
+		private void method() {
+			System.out.println();
+			System.out.println();
+			System.out.println();
+		}
+	}
+	// the huga bar method
+	public void bar(int test) {
+		System.out.println("aString");
+	}
+
+	public native void nativeMethod();
+
+	public strictfp float strictfpMethod() {
+		return 2.0f * 3.3f;
+	}
+}

--- a/src/test/java/ch/uzh/ifi/seal/changedistiller/unittest/ParentClassDeleteFailTest.java
+++ b/src/test/java/ch/uzh/ifi/seal/changedistiller/unittest/ParentClassDeleteFailTest.java
@@ -1,0 +1,52 @@
+package ch.uzh.ifi.seal.changedistiller.unittest;
+
+/*
+ * #%L
+ * ChangeDistiller
+ * %%
+ * Copyright (C) 2011 - 2018 Software Architecture and Evolution Lab, Department of Informatics, UZH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ch.uzh.ifi.seal.changedistiller.model.entities.SourceCodeChange;
+
+public class ParentClassDeleteFailTest {
+	List<SourceCodeChange> sourceCodeChangeList;
+
+	@Before
+	public void setUp() {
+		sourceCodeChangeList = FileDistillerUtil.getChangesFromFile("ParentClassDeleteFail_Left.java", "ParentClassDeleteFail_Right.java");
+	}
+
+	@Test
+	public void classRenamingTest() {
+		String expected = "PARENT_CLASS_DELETE\n";
+
+		StringBuilder stringBuilder = new StringBuilder();
+		for(SourceCodeChange change : sourceCodeChangeList) {
+			stringBuilder.append(change.getLabel() + "\n");
+		}
+
+		assertEquals(expected,stringBuilder.toString());
+	}
+}

--- a/src/test/java/ch/uzh/ifi/seal/changedistiller/unittest/ParentClassDeleteTest.java
+++ b/src/test/java/ch/uzh/ifi/seal/changedistiller/unittest/ParentClassDeleteTest.java
@@ -1,0 +1,52 @@
+package ch.uzh.ifi.seal.changedistiller.unittest;
+
+/*
+ * #%L
+ * ChangeDistiller
+ * %%
+ * Copyright (C) 2011 - 2018 Software Architecture and Evolution Lab, Department of Informatics, UZH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ch.uzh.ifi.seal.changedistiller.model.entities.SourceCodeChange;
+
+public class ParentClassDeleteTest {
+	List<SourceCodeChange> sourceCodeChangeList;
+
+	@Before
+	public void setUp() {
+		sourceCodeChangeList = FileDistillerUtil.getChangesFromFile("ParentClassDelete_Left.java", "ParentClassDelete_Right.java");
+	}
+
+	@Test
+	public void classRenamingTest() {
+		String expected = "PARENT_CLASS_DELETE\nINCREASING_ACCESSIBILITY_CHANGE\n";
+
+		StringBuilder stringBuilder = new StringBuilder();
+		for(SourceCodeChange change : sourceCodeChangeList) {
+			stringBuilder.append(change.getLabel() + "\n");
+		}
+
+		assertEquals( expected,stringBuilder.toString());
+	}
+}


### PR DESCRIPTION
When the only change between two files is a PARENT_CLASS_DELETE, changedistiller can't detect that change.
Parent Class Delete is only detected when there is another change beside it.
For this particular test, the extra change is increasing the accessibility of foo method in line 28 by making it public instead of protected.