### PR TITLE
PARENT_CLASS_CHANGE unit test added for issue #28

### DIFF
--- a/resources/testdata/src_changetypes/ParentClassChange_Left.java
+++ b/resources/testdata/src_changetypes/ParentClassChange_Left.java
@@ -1,0 +1,74 @@
+package test;
+
+/**
+ * This is our first (left) test class.
+ * @author Beat Fluri
+ */
+public class Test extends Left {
+	
+	/*
+	 * Scarab Lord Kungen
+	 */
+	public String aField;
+
+	public static String sField;
+	public volatile int vField;
+	public transient String tField;
+	public synchronized long synchField;
+	
+	private String arrayField;
+	
+	public Integer anInteger = new Integer(1);
+	
+	/**
+	 * Yet another method with a comment
+	 * @param number
+	 * @return
+	 */
+	public int foo(int number) {
+		System.out.println("left");
+		
+		// check if number is greater than -1
+		boolean check = number > 0;
+		int a = 0;
+		int b = 2;
+
+		// check the huga number
+		// and some new
+
+		if (check) {
+			/* This is the most beautiful comment in the world
+			 * and soon it will be gone :'(
+			 */
+			a = 23 + Integer.parseInt("42");
+			b = Math.round(Math.random() /* mimimi */);
+			return a + b;
+		} else {
+			/* huga bimbo */
+			b = Math.abs(number);
+			String.valueOf(true);
+			return b;
+		}
+	}
+	/*
+	 * Inner classes are cool
+	 */	
+	
+	private class Bar {
+		private void method() {
+			System.out.println();
+			System.out.println();
+			System.out.println();
+		}
+	}
+	// the huga bar method
+	public void bar(int test) {
+		System.out.println("aString");
+	}
+
+	public native void nativeMethod();
+	
+	public strictfp float strictfpMethod() {
+		return 2.0f * 3.3f;
+	}
+}

--- a/resources/testdata/src_changetypes/ParentClassChange_Right.java
+++ b/resources/testdata/src_changetypes/ParentClassChange_Right.java
@@ -30,8 +30,8 @@ public class Test extends Right {
 		
 		// check if number is greater than -1
 		boolean check = number > 0;
-		int a = 0;
 		int b = 2;
+		int a = 0;
 
 		// check the huga number
 		// and some new

--- a/resources/testdata/src_changetypes/ParentClassChange_Right.java
+++ b/resources/testdata/src_changetypes/ParentClassChange_Right.java
@@ -1,0 +1,74 @@
+package test;
+
+/**
+ * This is our first (left) test class.
+ * @author Beat Fluri
+ */
+public class Test extends Right {
+	
+	/*
+	 * Scarab Lord Kungen
+	 */
+	public String aField;
+
+	public static String sField;
+	public volatile int vField;
+	public transient String tField;
+	public synchronized long synchField;
+	
+	private String arrayField;
+	
+	public Integer anInteger = new Integer(1);
+	
+	/**
+	 * Yet another method with a comment
+	 * @param number
+	 * @return
+	 */
+	public int foo(int number) {
+		System.out.println("left");
+		
+		// check if number is greater than -1
+		boolean check = number > 0;
+		int a = 0;
+		int b = 2;
+
+		// check the huga number
+		// and some new
+
+		if (check) {
+			/* This is the most beautiful comment in the world
+			 * and soon it will be gone :'(
+			 */
+			a = 23 + Integer.parseInt("42");
+			b = Math.round(Math.random() /* mimimi */);
+			return a + b;
+		} else {
+			/* huga bimbo */
+			b = Math.abs(number);
+			String.valueOf(true);
+			return b;
+		}
+	}
+	/*
+	 * Inner classes are cool
+	 */	
+	
+	private class Bar {
+		private void method() {
+			System.out.println();
+			System.out.println();
+			System.out.println();
+		}
+	}
+	// the huga bar method
+	public void bar(int test) {
+		System.out.println("aString");
+	}
+
+	public native void nativeMethod();
+	
+	public strictfp float strictfpMethod() {
+		return 2.0f * 3.3f;
+	}
+}

--- a/src/test/java/ch/uzh/ifi/seal/changedistiller/unittest/ParentClassChangeTest.java
+++ b/src/test/java/ch/uzh/ifi/seal/changedistiller/unittest/ParentClassChangeTest.java
@@ -1,0 +1,51 @@
+package ch.uzh.ifi.seal.changedistiller.unittest;
+
+/*
+ * #%L
+ * ChangeDistiller
+ * %%
+ * Copyright (C) 2011 - 2018 Software Architecture and Evolution Lab, Department of Informatics, UZH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ch.uzh.ifi.seal.changedistiller.model.entities.SourceCodeChange;
+
+public class ParentClassChangeTest {
+	List<SourceCodeChange> sourceCodeChangeList;
+	
+	@Before
+	public void setUp() {
+		sourceCodeChangeList = FileDistillerUtil.getChangesFromFile("ParentClassChange_Left.java", "ParentClassChange_Right.java");
+	}
+	
+	@Test
+	public void ParentClassChangeTest() {
+		String expected = "PARENT_CLASS_CHANGE\n";
+		
+		StringBuilder stringBuilder = new StringBuilder();
+		for(SourceCodeChange change : sourceCodeChangeList) {
+			stringBuilder.append(change.getLabel() + "\n");
+		}
+		
+		assertEquals(stringBuilder.toString(), expected);
+	}
+}

--- a/src/test/java/ch/uzh/ifi/seal/changedistiller/unittest/ParentClassChangeTest.java
+++ b/src/test/java/ch/uzh/ifi/seal/changedistiller/unittest/ParentClassChangeTest.java
@@ -39,7 +39,7 @@ public class ParentClassChangeTest {
 	
 	@Test
 	public void ParentClassChangeTest() {
-		String expected = "PARENT_CLASS_CHANGE\n";
+		String expected = "PARENT_CLASS_CHANGE\nSTATEMENT_ORDERING_CHANGE\n";
 		
 		StringBuilder stringBuilder = new StringBuilder();
 		for(SourceCodeChange change : sourceCodeChangeList) {


### PR DESCRIPTION
ParentClassChangeTest checks whether a class' parent class is changed between StatementOrderingChange_Left and StatementOrderingChange_Right.

When PARENT_CLASS_CHANGE is the only change, ChangeDistiller cannot detect that change. In the first commit, PARENT_CLASS_CHANGE which can be seen in line 7 is not detected. Therefore, the test fails.

If there is another change, PARENT_CLASS_CHANGE is detected. In the second commit, there is also STATEMENT_ORDERING_CHANGE in lines 33-34. Therefore, the test passes.